### PR TITLE
Update a1.sh

### DIFF
--- a/etc/device-quirks/scripts/aokzoe/a1/a1.sh
+++ b/etc/device-quirks/scripts/aokzoe/a1/a1.sh
@@ -4,11 +4,11 @@ if [ $(whoami) != 'root' ]; then
    exit 1
 fi
  
-# Force 16 bit audio, format S16LE, rate 192000.
+# Force 16 bit audio, format S16LE, sample rate 96000.
 cp -a /usr/share/wireplumber /etc/
 sed -i 's/--\["audio.format"\]/\["audio.format"\]/' /etc/wireplumber/main.lua.d/50-alsa-config.lua
 sed -i 's/--\["audio.rate"\]/\["audio.rate"\]/' /etc/wireplumber/main.lua.d/50-alsa-config.lua
-sed -i 's/44100/192000/' /etc/wireplumber/main.lua.d/50-alsa-config.lua
+sed -i 's/44100/96000/' /etc/wireplumber/main.lua.d/50-alsa-config.lua
 
 # Fix rotation of TTY's.
 cp $DQ_PATH/scripts/aokzoe/a1/a1_fbcon.conf /etc/tmpfiles.d/a1_fbcon.conf


### PR DESCRIPTION
concerns have been made over 192000hz sampling rate. It does consume more memory than 96000 and could theoretically consume more CPU resources if the DSP isn't handling it. Reducing to 96000 which is standard for bluray.