### PR TITLE
Add needed blacklists for xone

### DIFF
--- a/usr/lib/modprobe.d/modules-tweaks.conf
+++ b/usr/lib/modprobe.d/modules-tweaks.conf
@@ -1,7 +1,6 @@
 # steam controller fix, xbox one s bluetooth fix, amdgpu setup
 blacklist hid_steam
 blacklist radeon
-blacklist xpad
 blacklist mt76x2u
 options amdgpu si_support=1
 options amdgpu cik_support=1

--- a/usr/lib/modprobe.d/modules-tweaks.conf
+++ b/usr/lib/modprobe.d/modules-tweaks.conf
@@ -1,6 +1,8 @@
 # steam controller fix, xbox one s bluetooth fix, amdgpu setup
 blacklist hid_steam
 blacklist radeon
+blacklist xpad
+blacklist mt76x2u
 options amdgpu si_support=1
 options amdgpu cik_support=1
 options amdgpu noretry=0


### PR DESCRIPTION
The blacklist devices for xone seems to be missing in the images.
- https://github.com/medusalix/xone/blob/master/install/modprobe.conf