### PR TITLE
Add AMDGPU power profile setter

### DIFF
--- a/usr/lib/udev/rules.d/30-amdgpu-power-profile.rules
+++ b/usr/lib/udev/rules.d/30-amdgpu-power-profile.rules
@@ -1,0 +1,3 @@
+# Set AMDGPU power profile to 3d_FULL_SCREEN. Seems to solve low performance issues with some 6000 series devices.
+# See https://wiki.archlinux.org/title/AMDGPU#Power_profiles and https://gitlab.freedesktop.org/drm/amd/-/issues/1500#note_1863440
+KERNEL=="card[0-9]", SUBSYSTEM=="drm", DRIVERS=="amdgpu", ATTR{device/power_dpm_force_performance_level}="manual", ATTR{device/pp_power_profile_mode}="1"


### PR DESCRIPTION
Workaround for the issue specified [here](https://gitlab.freedesktop.org/drm/amd/-/issues/1500#note_1863440) on 6000 series dGPU's. Has no affect on APU's. We'll need to verify no adverse affect to other AMDGPU cards Southern islands and after.

This will not require edits to the PKGBUILD as usr/lib/udev/rules.d is already being installed with *