### PR TITLE
fix aya neo 2 being detected as aya neo 2021

### DIFF
--- a/usr/share/device-quirks/id-device
+++ b/usr/share/device-quirks/id-device
@@ -10,22 +10,22 @@ GPD_LIST="GPD"
 OXP_LIST="ONE-NETBOOK TECHNOLOGY CO., LTD."
 
 # AOKZOE Devices
-if [[ ":$AOK_LIST:" =~ "${VENDOR}" ]]; then
+if [[ ":$AOK_LIST:" =~ ":${VENDOR}:" ]]; then
     echo "AOKZOE Device Found!"
     $DQ_PATH/scripts/aokzoe/aokzoe_table.sh
 
 # Aya Neo Devices
-elif [[ ":$AYANEO_LIST:" =~ "${VENDOR}" ]]; then
+elif [[ ":$AYANEO_LIST:" =~ ":${VENDOR}:" ]]; then
     echo "AYANEO Device Found!"
     $DQ_PATH/scripts/ayaneo/ayaneo_table.sh
 
 # GPD Devices
-elif [[ ":$GPD_LIST:" =~ "${VENDOR}" ]]; then
+elif [[ ":$GPD_LIST:" =~ ":${VENDOR}:" ]]; then
     echo "GPD Device Found!"
     $DQ_PATH/scripts/gpd/gpd_table.sh
 
 # OXP Devices
-elif [[ ":$OXP_LIST:" =~ "${VENDOR}" ]]; then
+elif [[ ":$OXP_LIST:" =~ ":${VENDOR}:" ]]; then
     echo "OXP Device Found!"
     $DQ_PATH/scripts/oxp/oxp_table.sh
 

--- a/usr/share/device-quirks/scripts/ayaneo/ayaneo_table.sh
+++ b/usr/share/device-quirks/scripts/ayaneo/ayaneo_table.sh
@@ -5,13 +5,13 @@ PRODUCT_LIST_2021="AYA NEO Founder:AYA NEO 2021:AYANEO 2021:AYANEO 2021 Pro:AYAN
 PRODUCT_LIST_AIR_PLUS="AIR Plus"
 PRODUCT_LIST_2="AYANEO 2:GEEK"
 
-if [[ ":$PRODUCT_LIST_2021:" =~ "$PRODUCT_NAME" ]]; then
+if [[ ":$PRODUCT_LIST_2021:" =~ ":$PRODUCT_NAME:" ]]; then
   echo "AYA NEO 2021 Device"
   $DQ_PATH/scripts/ayaneo/2021/2021.sh
-elif [[ ":$PRODUCT_LIST_AIR_PLUS:" =~ "$PRODUCT_NAME" ]]; then
+elif [[ ":$PRODUCT_LIST_AIR_PLUS:" =~ ":$PRODUCT_NAME:" ]]; then
   echo "AYA NEO AIR PLUS"
   $DQ_PATH/scripts/ayaneo/air_plus/air_plus.sh
-elif [[ ":$PRODUCT_LIST_2:" =~ "$PRODUCT_NAME" ]]; then
+elif [[ ":$PRODUCT_LIST_2:" =~ ":$PRODUCT_NAME:" ]]; then
   echo "AYA NEO 2 SERIES"
   $DQ_PATH/scripts/ayaneo/2/2.sh
 else

--- a/usr/share/device-quirks/scripts/gpd/gpd_table.sh
+++ b/usr/share/device-quirks/scripts/gpd/gpd_table.sh
@@ -12,14 +12,14 @@ BOARD_WM2="G1618-04"
 BOARD_WIN4="G1619-04"
 
 # WinMax2
-elif [[ ":$BOARD_WM2:" =~ "$BOARD_NAME" ]]; then
+if [[ ":$BOARD_WM2:" =~ ":$BOARD_NAME:" ]]; then
   echo "WinMax2"
   $DQ_PATH/scripts/gpd/winmax2/winmax2.sh
-elif [[ ":$BOARD_WIN4:" =~ "$BOARD_NAME" ]]; then
+elif [[ ":$BOARD_WIN4:" =~ ":$BOARD_NAME:" ]]; then
   echo "Win4"
   $DQ_PATH/scripts/gpd/win4/win4.sh
 
 # No Match
 else
-  echo "${PRODUCT_NAME} does not have a quirk configuration script. Exiting."
+  echo "${BOARD_NAME} does not have a quirk configuration script. Exiting."
 fi


### PR DESCRIPTION
- add `:` to force exact match when comparing vendor/product/board names
- fix GPD script

For each modified script, tested:
 - each possible value manually
 - a non-matching value