### PR TITLE
[dsdt] fix override for v314 ALLY dsl

### DIFF
--- a/usr/lib/firmware/dsdt/rog_ally_v314.dsl
+++ b/usr/lib/firmware/dsdt/rog_ally_v314.dsl
@@ -18,7 +18,7 @@
  *     Compiler ID      "INTL"
  *     Compiler Version 0x20200717 (538969879)
  */
-DefinitionBlock ("", "DSDT", 2, "ALASKA", "A M I ", 0x01072009)
+DefinitionBlock ("", "DSDT", 2, "ALASKA", "A M I ", 0x0107200a)
 {
     External (_SB_.ALIB, MethodObj)    // 2 Arguments
     External (_SB_.ALS_, DeviceObj)


### PR DESCRIPTION
Value needs to be '0x0107200a' to override the DSDT