### PR TITLE
Add missing dsdt from list of air_plus models

### DIFF
--- a/usr/share/device-quirks/scripts/ayaneo/air_plus/air_plus.sh
+++ b/usr/share/device-quirks/scripts/ayaneo/air_plus/air_plus.sh
@@ -15,7 +15,7 @@ echo "Force S16LE 96000hz"
 $DQ_PATH/scripts/override_bitrate
 
 # Do DSDT override.
-DSDT_OVERRIDES="ayaneo_air_plus_D16_0x0D.dsl ayaneo_air_plus_D16_0xCF.dsl ayaneo_air_plus_D16_0x0F.dsl ayaneo_air_plus_D32_0x94.dsl ayaneo_air_plus_D32_0xD4.dsl"
+DSDT_OVERRIDES="ayaneo_air_plus_D16_0x0D.dslayaneo_air_plus_D16_0x0F.dsl ayaneo_air_plus_D16_0x7D.dsl ayaneo_air_plus_D16_0xCF.dsl ayaneo_air_plus_D32_0x94.dsl ayaneo_air_plus_D32_0xD4.dsl"
 if [[ $USE_FIRMWARE_OVERRIDES == 1 ]]; then
   $DQ_PATH/scripts/override_dsdt $DSDT_OVERRIDES
 else


### PR DESCRIPTION
https://github.com/ChimeraOS/device-quirks/commit/9c492edc33d268d757e43ba1d112e4bd8721c4c4 didn;t add the DSDT to the air_plus list. This fixes it.