### PR TITLE
modprobe updates

### DIFF
--- a/usr/lib/modprobe.d/modules-tweaks.conf
+++ b/usr/lib/modprobe.d/modules-tweaks.conf
@@ -1,5 +1,3 @@
-# Steam controller fix
-blacklist hid_steam
 # prevents messages appearing during reboot
 blacklist sp5100_tco
 # enable Vulkan support on older AMD graphics cards

--- a/usr/lib/modprobe.d/modules-tweaks.conf
+++ b/usr/lib/modprobe.d/modules-tweaks.conf
@@ -7,6 +7,8 @@ blacklist radeon
 options amdgpu si_support=1
 options amdgpu cik_support=1
 options amdgpu noretry=0
+# enable Vulkan support on older Intel iGPUs
+options i915 force_probe="*"
 # fix Bluetooth issues with Xbox One X|S controllers
 options bluetooth disable_ertm=1
 # enable audio power savings

--- a/usr/lib/modprobe.d/modules-tweaks.conf
+++ b/usr/lib/modprobe.d/modules-tweaks.conf
@@ -1,9 +1,13 @@
-# steam controller fix, xbox one s bluetooth fix, amdgpu setup
+# Steam controller fix
 blacklist hid_steam
-blacklist radeon
+# prevents messages appearing during reboot
 blacklist sp5100_tco
+# enable Vulkan support on older AMD graphics cards
+blacklist radeon
 options amdgpu si_support=1
 options amdgpu cik_support=1
 options amdgpu noretry=0
+# fix Bluetooth issues with Xbox One X|S controllers
 options bluetooth disable_ertm=1
+# enable audio power savings
 options snd_hda_intel power_save=1


### PR DESCRIPTION
These patches all add various updates to the modprobe configuration:

* Comments are added to explain each workaround.
* Older Intel iGPUs have Vulkan support enabled.
* Very old AMD/ATI GPUs are supported again.
    * I can understand if this is not desired. Let me know and I can drop the last patch.