### PR TITLE
fix pipewire equalizer filename and change path

### DIFF
--- a/usr/share/device-quirks/scripts/asus/ally/ally.sh
+++ b/usr/share/device-quirks/scripts/asus/ally/ally.sh
@@ -5,5 +5,5 @@ if [ $(whoami) != 'root' ]; then
 fi
 
 # Create an equalizer for pipewire.
-mkdir -p ~/.config/pipewire/pipewire.conf.d
-cp $DQ_PATH/scripts/asus/ally/sink-eq6.conf ~/.config/pipewire/pipewire.conf.d/sink-eq6.conf
+mkdir -p /etc/pipewire/pipewire.conf.d
+cp $DQ_PATH/scripts/asus/ally/sink-eq.conf /etc/pipewire/pipewire.conf.d/sink-eq.conf


### PR DESCRIPTION
First, there is an error in the file name of cp. The actual file name is [sink-eq.conf](https://github.com/ChimeraOS/device-quirks/blob/main/usr/share/device-quirks/scripts/asus/ally/sink-eq.conf). 

Secondly, I think it's more appropriate to copy it directly to the etc path because the script is executed as the root user, and the original cp command will create it in the root home directory.