### PR TITLE
Fix systemd-suspend-mods.sh

### DIFF
--- a/usr/lib/systemd/system-sleep/systemd-suspend-mods.sh
+++ b/usr/lib/systemd/system-sleep/systemd-suspend-mods.sh
@@ -3,15 +3,17 @@
 # in /etc/device-quirks/systemd-suspend-mods.conf and rmmod them on suspend,
 # insmod them on resume.
 
+MOD_LIST=$(grep -v ^\# /etc/device-quirks/systemd-suspend-mods.conf)
+
 case $1 in
     pre)
-        for mod in $(</etc/device-quirks/systemd-suspend-mods.conf); do
-            rmmod $mod
+        for mod in $MOD_LIST; do
+            modprobe -r $mod
         done
     ;;
     post)
-        for mod in $(</etc/device-quirks/systemd-suspend-mods.conf); do
-            insmod $mod
+        for mod in $MOD_LIST; do
+            modprobe $mod
         done
     ;;
 esac


### PR DESCRIPTION
- Using `modprobe` to reload kernel modules instead of `insmod` and `rmmod`
- Using grep regax to avoid reading comment

At the same time, the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=chimeraos-device-quirks-git) in AUR package has a mistake:

```
# PKGBUILD: 41
install -v -m644 -D -t "${pkgdir}/usr/lib/systemd/system-sleep/" usr/lib/systemd/system-sleep/*
```

This give wrong permission to the script that makes it unable to be executed.