### PR TITLE
fix(Ally):Resolve suspend issues

### DIFF
--- a/usr/lib/systemd/system-sleep/systemd-suspend-mods.sh
+++ b/usr/lib/systemd/system-sleep/systemd-suspend-mods.sh
@@ -5,6 +5,13 @@
 
 MOD_LIST=$(grep -v ^\# /etc/device-quirks/systemd-suspend-mods.conf)
 
+PRODUCT=$(cat /sys/devices/virtual/dmi/id/product_name)
+ROG_LIST="ROG Ally RC71L_RC71L:ROG Ally RC71L"
+
+if [[ ":$ROG_LIST:" =~ ":$PRODUCT:" ]]; then
+    exit 0
+fi
+
 case $1 in
     pre)
         for mod in $MOD_LIST; do


### PR DESCRIPTION
unload mt7921e will cause ROG Ally to be unable to suspend
Considering that the systemd-suspend-mods.conf currently only has one item mt7921e.
So for ally, with an exit.