### PR TITLE
fix(GPD): udev rules for disabling the fingerprint scanners on WM2 and Win 4

### DIFF
--- a/usr/lib/udev/rules.d/50-fingerprint.rules
+++ b/usr/lib/udev/rules.d/50-fingerprint.rules
@@ -1,1 +1,7 @@
 ACTION=="add", SUBSYSTEM=="usb", TEST=="power/control", ATTR{idVendor}=="1c7a", ATTR{idProduct}=="0588", ATTR{power/control}="auto"
+
+# remove fp sensor for GPD Win 4
+SUBSYSTEM=="usb", ATTR{idVendor}=="2808", ATTR{idProduct}=="9338", ATTR{remove}="1"
+
+# remove fp sensor for GPD Win Max 2
+SUBSYSTEM=="usb", ATTR{idVendor}=="2541", ATTR{idProduct}=="9711", ATTR{remove}="1"


### PR DESCRIPTION
GPD devices occasionally have issues when resuming from suspend.

While fairly infrequent, when it does happen, the device locks up for several seconds before finally resuming

disabling the FP sensor clears up the issue on the GPD WM2, and while I've only done preliminary testing so far on the Win 4, seems to also clear up the same issue

Tested on:

- GPD Win Max 2 6800u
- GPD Win 4 6800u