### PR TITLE
fix(MT7922): Fix MT7922 netdev_config quirk.

### DIFF
--- a/usr/share/device-quirks/id-device
+++ b/usr/share/device-quirks/id-device
@@ -47,10 +47,10 @@ elif [[ ":$OXP_LIST:" =~ ":${VENDOR}:" ]]; then
     echo "OXP Device Found!"
     $DQ_PATH/scripts/oxp/oxp_table.sh
 
+# Run networking devices configuration script.
+$DQ_PATH/scripts/netdev_config.sh
+
 # Unrecognized Device
 else
     echo "${VENDOR} does not have any supported models. Exiting."
 fi
-
-# Run networking devices configuration script.
-$DQ_PATH/scripts/netdev_config.sh

--- a/usr/share/device-quirks/scripts/netdev_config.sh
+++ b/usr/share/device-quirks/scripts/netdev_config.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
 
+echo "Starting Network Device Configuration."
+
 # Detect if the install media is running or not
-if [ ! -d /tmp/frzr_root ]; then
-  MOUNT_PATH=""
+MOUNT_PREFIX=""
+if [[ -d /tmp/frzr_root ]]; then
+  echo "Running as install."
+  MOUNT_PREFIX=$MOUNT_PATH
+else
+  echo "Running as upgrade."
 fi
 
-if [[ ! -z $(lspci | grep "MT7922") ]];
-then
-	echo "Removing MT7921E quirk from device with MT7922."
-	sed -i 's/mt7921e//g' ${MOUNT_PATH}/etc/device-quirks/systemd-suspend-mods.conf
+# Remove MT7921E quirk for MT7922 devices.
+if [[ ! -z $(lspci | grep "MT7922") ]]; then
+  EDIT_FILE=${MOUNT_PREFIX}/etc/device-quirks/systemd-suspend-mods.conf
+  if [[ ! -f ${EDIT_FILE} ]]; then
+    echo "Unable to source ${EDIT_FILE}. MT7922 quirk NOT APPLIED. Exiting. "
+  else
+    echo "Removing MT7921E quirk from device with MT7922."
+    sed -i 's/mt7921e//g' ${EDIT_FILE}
+  fi
 fi
+
+echo "Network Device Configuration completed."


### PR DESCRIPTION
Installs on devices with MT7922 devices have been failing due to the file `/etc/device-quirks/systemd-suspend-mods.conf` not being present on the installation media. There seems to be an issue somewhere with detecting `/tmp/frzr_root` or setting `MOUNT_POINT` env properly. This change adds safety to the `sed` call so installations wont fail, as well as adding logging to the script so we can better identify where this is failing.