### PR TITLE
Add udev rules for gyro and wheel style controllers.

### DIFF
--- a/usr/lib/udev/rules.d/71-fanatec-controllers.rules
+++ b/usr/lib/udev/rules.d/71-fanatec-controllers.rules
@@ -1,0 +1,19 @@
+# Copied from https://github.com/gotzl/hid-fanatecff/blob/master/fanatec.rules
+# with some changes so that anyone can change configs
+
+ACTION!="add|change", GOTO="fanatec_end"
+SUBSYSTEM=="hid", DRIVER=="fanatec", GOTO="ftec_module_settings"
+SUBSYSTEM=="input", DRIVERS=="fanatec", GOTO="ftec_input_settings"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0eb7", MODE="0666"
+GOTO="fanatec_end"
+
+LABEL="ftec_module_settings"
+RUN+="/bin/sh -c 'cd %S%p; chmod 666 range display load rumble leds/*/brightness tuning_menu/*"
+GOTO="fanatec_end"
+
+LABEL="ftec_input_settings"
+# remove deadzone/fuzz
+RUN{program}+="/usr/bin/evdev-joystick --evdev $devnode --deadzone 0 --fuzz 0"
+GOTO="fanatec_end"
+
+LABEL="fanatec_end"

--- a/usr/lib/udev/rules.d/71-logitec-controllers.rules
+++ b/usr/lib/udev/rules.d/71-logitec-controllers.rules
@@ -1,0 +1,71 @@
+# Match kernel name of device, rather than ATTRS{idProduct} and ATTRS{idVendor}
+# so we can access the range file and leds directory. Set rw access to these 
+# files for everyone.
+# Avoid blanket matching all Logitech devices, as that causes issues with mice,
+# keyboards, and other non-wheel devices.
+
+ACTION!="unbind", ACTION!="remove", SUBSYSTEM=="hid", ATTRS{idVendor}=="046d" GOTO="logitech-rules"
+GOTO="end"
+
+LABEL="logitech-rules"
+
+DRIVER=="logitech" GOTO="logitech-driver"
+DRIVER!="logitech-hidpp-device" GOTO="end"
+
+# Logitech G PRO Racing Wheel for Xbox One and PC
+ATTRS{idProduct}=="c272", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G923 Racing Wheel for Xbox One and PC
+ATTRS{idProduct}=="c26e", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G920 Driving Force Racing Wheel
+ATTRS{idProduct}=="c262", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range'"
+
+GOTO="end"
+
+LABEL="logitech-driver"
+
+# Logitech G923 Racing Wheel for PlayStation 4 and PC
+ATTRS{idProduct}=="c266", RUN+="/bin/sh -c 'cd %S%p; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G29 Driving Force Racing Wheel
+ATTRS{idProduct}=="c24f", RUN+="/bin/sh -c 'cd %S%p; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G27 Driving Force Racing Wheel
+ATTRS{idProduct}=="c29b", RUN+="/bin/sh -c 'cd %S%p; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G25 Driving Force Racing Wheel
+ATTRS{idProduct}=="c299", RUN+="/bin/sh -c 'cd %S%p; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Driving Force GT Racing Wheel
+ATTRS{idProduct}=="c29a", RUN+="/bin/sh -c 'cd %S%p; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Driving Force Pro Racing Wheel
+ATTRS{idProduct}=="c298", RUN+="/bin/sh -c 'cd %S%p; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Driving Force Racing Wheel
+ATTRS{idProduct}=="c294", RUN+="/bin/sh -c 'cd %S%p; chmod 666 combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Momo Force Racing Wheel
+ATTRS{idProduct}=="c295", RUN+="/bin/sh -c 'cd %S%p; chmod 666 combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech MOMO Racing USB
+ATTRS{idProduct}=="ca03", RUN+="/bin/sh -c 'cd %S%p; chmod 666 combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech WingMan Formula Force GP USB
+ATTRS{idProduct}=="c293", RUN+="/bin/sh -c 'cd %S%p; chmod 666 combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Racing Wheel USB
+ATTRS{idProduct}=="ca04", RUN+="/bin/sh -c 'cd %S%p; chmod 666 combine_pedals range'"
+
+# Logitech WingMan Formula GP
+ATTRS{idProduct}=="c20e", RUN+="/bin/sh -c 'cd %S%p; chmod 666 combine_pedals range'"
+
+# Logitech WingMan Formula (Yellow) (USB)
+ATTRS{idProduct}=="c202", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range'"
+
+# Logitech Speed Force Wireless
+ATTRS{idProduct}=="c29c", RUN+="/bin/sh -c 'cd %S%p; chmod 666 combine_pedals range'"
+
+LABEL="end"
+

--- a/usr/lib/udev/rules.d/71-nintendo-controllers.rules
+++ b/usr/lib/udev/rules.d/71-nintendo-controllers.rules
@@ -1,0 +1,15 @@
+# Nintendo Switch Pro Controller; Bluetooth; USB
+KERNEL=="hidraw*", KERNELS=="*057E:2009*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="057e", ATTR{idProduct}=="2009", ENV{ID_INPUT_JOYSTICK}="1", TAG+="uaccess"
+
+# Nintendo Switch Joy-Con Charging Grip; USB
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="200e", MODE="0660", TAG+="uaccess"
+
+# Nintendo Switch Joy-Con (L); Bluetooth
+KERNEL=="hidraw*", KERNELS=="*057E:2006*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2006", MODE="0660", TAG+="uaccess"
+
+# Nintendo Switch Joy-Con (R); Bluetooth
+KERNEL=="hidraw*", KERNELS=="*057E:2007*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2007", MODE="0660", TAG+="uaccess"

--- a/usr/lib/udev/rules.d/71-sony-controllers.rules
+++ b/usr/lib/udev/rules.d/71-sony-controllers.rules
@@ -1,3 +1,27 @@
-# Sony DualSense Edge Wireless-Controller; bluetooth; USB
+# Sony PlayStation Strikepack; USB
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="05c5", MODE="0660", TAG+="uaccess"
+
+# Sony PlayStation DualShock 3; Bluetooth; USB
+KERNEL=="hidraw*", KERNELS=="*054C:0268*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0268", MODE="0660", TAG+="uaccess"
+## Motion Sensors
+SUBSYSTEM=="input", KERNEL=="event*|input*", KERNELS=="*054C:0268*", TAG+="uaccess"
+
+# Sony PlayStation DualShock 4; Bluetooth; USB
+KERNEL=="hidraw*", KERNELS=="*054C:05C4*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="05c4", MODE="0660", TAG+="uaccess"
+
+# Sony PlayStation DualShock 4 Slim; Bluetooth; USB
+KERNEL=="hidraw*", KERNELS=="*054C:09CC*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="09cc", MODE="0660", TAG+="uaccess"
+
+# Sony PlayStation DualShock 4 Wireless Adapter; USB
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0ba0", MODE="0660", TAG+="uaccess"
+
+# Sony DualSense Wireless-Controller; Bluetooth; USB
+KERNEL=="hidraw*", KERNELS=="*054C:0CE6*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0ce6", MODE="0660", TAG+="uaccess"
+
+# Sony DualSense Edge Wireless-Controller; Bluetooth; USB
 KERNEL=="hidraw*", KERNELS=="*054C:0DF2*", MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0df2", MODE="0660", TAG+="uaccess"

--- a/usr/lib/udev/rules.d/71-thrustmaster-controllers.rules
+++ b/usr/lib/udev/rules.d/71-thrustmaster-controllers.rules
@@ -1,0 +1,49 @@
+# Match kernel name of device, rather than ATTRS{idProduct} and ATTRS{idVendor}
+# so we can access the range file and leds directory. Set rw access to these 
+# files for everyone.
+# Avoid blanket matching all Thrustmaster devices, as that causes issues with mice,
+# keyboards, and other non-wheel devices.
+
+ACTION!="unbind", ACTION!="remove", SUBSYSTEM=="hid", ATTRS{idVendor}=="044f" GOTO="thrustmaster-rules"
+GOTO="end"
+
+LABEL="thrustmaster-rules"
+
+DRIVER=="tmff2" GOTO="tmff-new"
+DRIVER=="hid-tmff-new" GOTO="tmff-new"
+DRIVER=="hid-t150" GOTO="t150"
+DRIVER!="t500rs" GOTO="end"
+
+# Thrustmaster T500RS Racing Wheel (USB)
+ATTRS{idProduct}=="b65e", DRIVER=="t500rs", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level'"
+
+GOTO="end"
+
+LABEL="tmff-new"
+
+# Thrustmaster T300RS Racing Wheel (USB)
+ATTRS{idProduct}=="b66e", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
+
+# Thrustmaster Ferrari F1 Wheel Advanced T300 (USB)
+ATTRS{idProduct}=="b66f", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
+
+# Thrustmaster T300RS GT Racing Wheel (USB)
+ATTRS{idProduct}=="b66d", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
+
+# Thrustmaster T248 Racing Wheel (USB)
+ATTRS{idProduct}=="b696", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level'"
+
+# Thrustmaster TS-XW Racing Wheel (USB)
+ATTRS{idProduct}=="b692", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain spring_level damper_level friction_level'"
+
+GOTO="end"
+
+LABEL="t150"
+
+# Thrustmaster T150 Racing Wheel (USB)
+ATTRS{idProduct}=="b677", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain autocenter'"
+
+# Thrustmaster TMX Racing Wheel (USB)
+ATTRS{idProduct}=="b67f", RUN+="/bin/sh -c 'cd %S%p; chmod 666 range gain autocenter'"
+
+LABEL="end"


### PR DESCRIPTION
Requires updating the [manifest](https://github.com/ChimeraOS/chimeraos/blob/5593fbb806998da09cb320dba902aa9feeb57b23/manifest#L290-L295) to remove duplicate rules found there.
