### PR TITLE
correction of both ROG Ally and Legion GO scripts.

### DIFF
--- a/usr/share/device-quirks/scripts/asus/scripts.d/ally_pipewire.sh
+++ b/usr/share/device-quirks/scripts/asus/scripts.d/ally_pipewire.sh
@@ -36,7 +36,7 @@ device_quirk_install(){
                 touch "${PIPEWIRE_DIR}/.ALLY-PIPEWIRE-CFG"
             fi
             echo "Pipewire configuration installed successfully."
-            return 0
+            # return 0  has to be removed so wireplumber install also runs
         else
             echo "Error renaming existing pipewire directory."
             return 1
@@ -45,7 +45,7 @@ device_quirk_install(){
         cp -r "${ALLY_PIPEWIRE_DIR}" "${DQ_WORKING_PATH}/etc/"
         if [ $? -eq 0 ]; then
             echo "Pipewire configuration installed successfully."
-            return 0
+            # return 0  has to be removed so wireplumber install also runs
         else
             echo "Error copying pipewire directory into /etc"
             return 1
@@ -90,7 +90,7 @@ device_quirk_removal(){
         rm -rf "${DQ_WORKING_PATH}/etc/pipewire"
         if [ $? -eq 0 ]; then
             echo "Successfully removed pipewire directory."
-            return 0
+            #return 0 # has to be removed so wireplumber configuration removal also runs
         else
             echo "Error removing pipewire directory."
             return 1

--- a/usr/share/device-quirks/scripts/asus/scripts.d/ally_x_pipewire.sh
+++ b/usr/share/device-quirks/scripts/asus/scripts.d/ally_x_pipewire.sh
@@ -36,7 +36,7 @@ device_quirk_install(){
                 touch "${PIPEWIRE_DIR}/.ALLY-X-PIPEWIRE-CFG"
             fi
             echo "Pipewire configuration installed successfully."
-            return 0
+            # return 0  has to be removed so wireplumber install also runs
         else
             echo "Error renaming existing pipewire directory."
             return 1
@@ -45,7 +45,7 @@ device_quirk_install(){
         cp -r "${ALLY_X_PIPEWIRE_DIR}" "${DQ_WORKING_PATH}/etc/"
         if [ $? -eq 0 ]; then
             echo "Pipewire configuration installed successfully."
-            return 0
+            # return 0  has to be removed so wireplumber install also runs
         else
             echo "Error copying pipewire directory into /etc"
             return 1
@@ -90,7 +90,7 @@ device_quirk_removal(){
         rm -rf "${DQ_WORKING_PATH}/etc/pipewire"
         if [ $? -eq 0 ]; then
             echo "Successfully removed pipewire directory."
-            return 0
+            #return 0 # has to be removed so wireplumber configuration removal also runs
         else
             echo "Error removing pipewire directory."
             return 1

--- a/usr/share/device-quirks/scripts/lenovo/scripts.d/go_pipewire.sh
+++ b/usr/share/device-quirks/scripts/lenovo/scripts.d/go_pipewire.sh
@@ -75,7 +75,7 @@ device_quirk_install(){
         cp -r "${LEGO_WIREPLUMBER_DIR}" "${DQ_WORKING_PATH}/etc/"
         if [ $? -eq 0 ]; then
             echo "Wireplumber configuration installed successfully."
-            #return 0
+            return 0
         else
             echo "Error copying wireplumber directory into /etc"
             return 1

--- a/usr/share/device-quirks/scripts/lenovo/scripts.d/go_pipewire.sh
+++ b/usr/share/device-quirks/scripts/lenovo/scripts.d/go_pipewire.sh
@@ -36,7 +36,7 @@ device_quirk_install(){
                 touch "${PIPEWIRE_DIR}/.GO-PIPEWIRE-CFG"
             fi
             echo "Pipewire configuration installed successfully."
-            return 0
+            # return 0  has to be removed so wireplumber install also runs
         else
             echo "Error renaming existing pipewire directory."
             return 1
@@ -45,7 +45,7 @@ device_quirk_install(){
         cp -r "${LEGO_PIPEWIRE_DIR}" "${DQ_WORKING_PATH}/etc/"
         if [ $? -eq 0 ]; then
             echo "Pipewire configuration installed successfully."
-            return 0
+           # return 0  has to be removed so wireplumber install also runs
         else
             echo "Error copying pipewire directory into /etc"
             return 1
@@ -66,7 +66,7 @@ device_quirk_install(){
                 touch "${WIREPLUMBER_DIR}/.GO-WIREPLUMBER-CFG"
             fi
             echo "Wireplumber configuration installed successfully."
-            return 0
+            #return 0
         else
             echo "Error renaming existing wireplumber directory."
             return 1
@@ -75,7 +75,7 @@ device_quirk_install(){
         cp -r "${LEGO_WIREPLUMBER_DIR}" "${DQ_WORKING_PATH}/etc/"
         if [ $? -eq 0 ]; then
             echo "Wireplumber configuration installed successfully."
-            return 0
+            #return 0
         else
             echo "Error copying wireplumber directory into /etc"
             return 1
@@ -90,7 +90,7 @@ device_quirk_removal(){
         rm -rf "${DQ_WORKING_PATH}/etc/pipewire"
         if [ $? -eq 0 ]; then
             echo "Successfully removed pipewire directory."
-            return 0
+            #return 0 # has to be removed so wireplumber configuration removal also runs
         else
             echo "Error removing pipewire directory."
             return 1


### PR DESCRIPTION
Removal of "return 0" in pipewire, both install and removal, have to be commented or removed so wireplumber code also runs.